### PR TITLE
fix

### DIFF
--- a/include/fast_io_core_impl/allocation/adapters.h
+++ b/include/fast_io_core_impl/allocation/adapters.h
@@ -53,7 +53,7 @@ inline constexpr ::std::size_t allocator_compute_aligned_total_size_impl(::std::
 
 inline void *allocator_adjust_ptr_to_aligned_impl(void *p, ::std::size_t alignment) noexcept
 {
-	void *aligned_ptr{reinterpret_cast<void *>((reinterpret_cast<::std::size_t>(p) + alignment) & (0 - alignment))};
+	void *aligned_ptr{reinterpret_cast<void *>((reinterpret_cast<::std::uintptr_t>(p) + alignment) & (0 - alignment))};
 	reinterpret_cast<void **>(aligned_ptr)[-1] = p;
 	return aligned_ptr;
 }
@@ -1253,7 +1253,7 @@ public:
 		}
 		else
 		{
-			auto newres{alloc::allocate_zero_aligned_at_least(alignof(T), n * sizeof(T))};
+			auto newres{alloc::allocate_aligned_zero_at_least(alignof(T), n * sizeof(T))};
 			return {reinterpret_cast<T *>(newres.ptr), newres.count / sizeof(T)};
 		}
 	}

--- a/include/fast_io_core_impl/char_category/char_category.h
+++ b/include/fast_io_core_impl/char_category/char_category.h
@@ -1859,7 +1859,9 @@ inline constexpr bool is_c_halfwidth(char_type ch) noexcept
 	using unsigned_char_type = ::std::make_unsigned_t<char_type>;
 	if constexpr (sizeof(char_type) < sizeof(char32_t))
 	{
-		return ch;
+		constexpr unsigned_char_type halfwidth_exclaimation_mark_val{u8'!'};
+		constexpr unsigned_char_type num{94};
+		return static_cast<unsigned_char_type>(ch - halfwidth_exclaimation_mark_val) < num;
 	}
 	else if constexpr (!::std::same_as<char_type, char32_t> && sizeof(char_type) == sizeof(char32_t))
 	{
@@ -1891,7 +1893,9 @@ inline constexpr bool is_c_fullwidth(char_type ch) noexcept
 	using unsigned_char_type = ::std::make_unsigned_t<char_type>;
 	if constexpr (sizeof(char_type) < sizeof(char32_t))
 	{
-		return ch;
+		constexpr unsigned_char_type fullwidth_exclaimation_mark_val{0xFF01};
+		constexpr unsigned_char_type num{94};
+		return static_cast<unsigned_char_type>(ch - fullwidth_exclaimation_mark_val) < num;
 	}
 	else if constexpr (!::std::same_as<char_type, char32_t> && sizeof(char_type) == sizeof(char32_t))
 	{

--- a/include/fast_io_core_impl/freestanding/algorithm.h
+++ b/include/fast_io_core_impl/freestanding/algorithm.h
@@ -532,13 +532,13 @@ inline constexpr ForwardIt lower_bound(ForwardIt first, ForwardIt last, T const 
 {
 	ForwardIt it;
 	typename ::std::iterator_traits<ForwardIt>::difference_type count, step;
-	count = last - first;
+	count = ::std::distance(first, last);
 
 	while (count > 0)
 	{
 		it = first;
 		step = count / 2;
-		it += step;
+		::std::advance(it, step);
 
 		if (comp(*it, value))
 		{
@@ -735,7 +735,7 @@ template <::std::input_iterator ForwardIt>
 inline constexpr void uninitialized_default_construct_n(ForwardIt first, ::std::size_t n) noexcept(
 	::std::is_nothrow_default_constructible_v<typename ::std::iterator_traits<ForwardIt>::value_type>)
 {
-	::fast_io::freestanding::uninitialized_default_construct(first, first + n);
+	::fast_io::freestanding::uninitialized_default_construct(first, ::std::next(first, n));
 }
 
 template <::std::input_iterator ForwardIt, typename T>
@@ -771,7 +771,7 @@ template <::std::input_iterator ForwardIt, typename T>
 inline constexpr void uninitialized_fill_n(ForwardIt first, ::std::size_t n, T const &x) noexcept(
 	::std::is_nothrow_copy_constructible_v<typename ::std::iterator_traits<ForwardIt>::value_type>)
 {
-	::fast_io::freestanding::uninitialized_fill(first, first + n, x);
+	::fast_io::freestanding::uninitialized_fill(first, ::std::next(first, n), x);
 }
 
 template <::std::forward_iterator ForwardIt>

--- a/include/fast_io_core_impl/freestanding/bytes.h
+++ b/include/fast_io_core_impl/freestanding/bytes.h
@@ -137,6 +137,7 @@ inline constexpr ::std::byte *nonoverlapped_bytes_copy(::std::byte const *first,
 }
 
 template <typename T>
+	requires(::std::is_trivially_copyable_v<T>) // make sure the type is trivially copyable for safely using memcpy
 inline constexpr ::std::byte const *type_punning_from_bytes(::std::byte const *__restrict first,
 															T &__restrict t) noexcept
 {
@@ -164,7 +165,7 @@ inline constexpr ::std::byte const *type_punning_from_bytes(::std::byte const *_
 }
 
 template <::std::size_t n, typename T>
-	requires(n <= sizeof(T))
+	requires(n <= sizeof(T) && ::std::is_trivially_copyable_v<T>)
 inline constexpr ::std::byte *type_punning_to_bytes_n(T const &__restrict first, ::std::byte *__restrict dest) noexcept
 {
 	if constexpr (n != 0)

--- a/include/fast_io_core_impl/integers/crypto_hash.h
+++ b/include/fast_io_core_impl/integers/crypto_hash.h
@@ -281,7 +281,7 @@ inline constexpr hash_compress_t<digest_format::upper, ctx> hash_compress_upper(
 	else
 	{
 		return {reinterpret_cast<::std::byte const *>(::std::ranges::data(t)),
-				static_cast<::std::size_t>(::std::ranges::size(t)) * sizeof(T)};
+				static_cast<::std::size_t>(::std::ranges::size(t)) * sizeof(::std::ranges::range_value_t<T>)};
 	}
 }
 
@@ -478,7 +478,7 @@ inline constexpr char_type *prv_srv_hash_compress_df_impl(char_type *iter, ::std
 				::std::byte buffer[digest_size];
 				auto ret{cal_hash_internal_impl<T>(base, len, buffer)};
 				return ::fast_io::details::copy_to_hash_df_commom_impl < d ==
-					   ::fast_io::manipulators::digest_format::upper > (buffer, iter, static_cast<::std::size_t>(ret - buffer));
+					   ::fast_io::manipulators::digest_format::upper > (iter, buffer, static_cast<::std::size_t>(ret - buffer));
 			}
 			else
 			{
@@ -512,7 +512,7 @@ inline constexpr char_type *prv_srv_hash_compress_df_impl(char_type *iter, ::std
 				::std::byte buffer[digest_size];
 				cal_hash_internal<T>(base, len, buffer);
 				return ::fast_io::details::copy_to_hash_df_commom_impl < d ==
-					   ::fast_io::manipulators::digest_format::upper > (buffer, iter, digest_size);
+					   ::fast_io::manipulators::digest_format::upper > (iter, buffer, digest_size);
 			}
 			else
 			{


### PR DESCRIPTION
- Fix function name  in allocation adapters
- Correct find_last return value for bidirectional iterators
- Use proper iterator operations for forward iterators
- Fix template parameters and length calculations in crypto hash